### PR TITLE
Add persistence-synced Y.Doc accessor functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "rollup-cli": "^1.0.9",
     "standard": "^12.0.1",
     "typescript": "^3.9.6",
-    "yjs": "13.0.5"
+    "yjs": "13.4.1"
   },
   "peerDependenies": {
     "yjs": "^13.0.0"


### PR DESCRIPTION
Provides one function for synchronized access to Y.Doc documents in the `y-websocket` server:
- `getOrCreateDoc`

This function can be used downstream by other server components to get or create stored documents, whether they are on-disk only, or in-memory.

This relates to discussion [here](https://discuss.yjs.dev/t/y-websocket-re-init-from-different-data-source/233) about allowing a little more access to the ydb-synced documents in general so that custom requirements (like truncating and other unsupported features) can be developed on top of Yjs.