### PR TITLE
feat: Add 'connecting' event

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -84,6 +84,11 @@ const setupWS = provider => {
     provider.wsconnecting = true
     provider.wsconnected = false
     provider.synced = false
+    
+    provider.emit('status', [{
+      status: 'connecting'
+    }])
+ 
     websocket.onmessage = event => {
       provider.wsLastMessageReceived = time.getUnixTime()
       const encoder = readMessage(provider, new Uint8Array(event.data), true)


### PR DESCRIPTION
As described in the [comment here](https://github.com/yjs/y-websocket/issues/7#issuecomment-623114183), a "connecting" event is useful for monkey-patching the authentication process in lieu of a more official API.

Seems like this is a no-brainer addition even if a more official auth API gets built on the client