### PR TITLE
fix: Message publishing happens down incorrect broadcast channel

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -146,7 +146,7 @@ const broadcastMessage = (provider, buf) => {
   }
   if (provider.bcconnected) {
     provider.mux(() => {
-      bc.publish(provider.url, buf)
+      bc.publish(provider.bcChannel, buf)
     })
   }
 }


### PR DESCRIPTION
Looks like this was missed as part of refactor in #12. I can't see any reason why it would be different?