### PR TITLE
fix: Remove unused _localAwarenessState

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -188,10 +188,6 @@ export class WebsocketProvider extends Observable {
     this.roomname = roomname
     this.doc = doc
     this._WS = WebSocketPolyfill
-    /**
-     * @type {Object<string,Object>}
-     */
-    this._localAwarenessState = {}
     this.awareness = awareness
     this.wsconnected = false
     this.wsconnecting = false


### PR DESCRIPTION
`_localAwarenessState` exists on constructor and is typed, but it is [never used](https://github.com/yjs/y-websocket/search?q=_localAwarenessState). Most likely vestigial?