### PR TITLE
fix: Move "connecting" event to be emitted after handlers are bound

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -85,10 +85,6 @@ const setupWS = provider => {
     provider.wsconnected = false
     provider.synced = false
 
-    provider.emit('status', [{
-      status: 'connecting'
-    }])
-
     websocket.onmessage = event => {
       provider.wsLastMessageReceived = time.getUnixTime()
       const encoder = readMessage(provider, new Uint8Array(event.data), true)
@@ -137,6 +133,10 @@ const setupWS = provider => {
         websocket.send(encoding.toUint8Array(encoderAwarenessState))
       }
     }
+    
+    provider.emit('status', [{
+      status: 'connecting'
+    }])
   }
 }
 


### PR DESCRIPTION
This allows the outer application to use this event to monkey-patch these methods, which was the original intent with the addition of this event.