### PR TITLE
fix: destroy doc awareness when closing document

### DIFF
--- a/bin/utils.js
+++ b/bin/utils.js
@@ -196,6 +196,7 @@ const closeConn = (doc, conn) => {
     if (doc.conns.size === 0 && persistence !== null) {
       // if persisted, we store state and destroy ydocument
       persistence.writeState(doc.name, doc).then(() => {
+        doc.awareness.destroy()
         doc.destroy()
       })
       docs.delete(doc.name)


### PR DESCRIPTION
While using persistence options, I noticed that disconnecting and reconnecting a sole client resulted in an uptick in memory usage that GC would not clear. I took a few heap snapshots and found retained memory in the vicinity of _checkInterval in y-protocols.Awareness. Seeing that Awareness had a destroy() method as well, I added that to closeConn in utils.js:187 . Further heap snapshots no longer showed retained memory in awareness.js.

This issue can be reproduced by enabling YPERSISTENCE in y-websocket, then forcing a singular client to connect and disconnect repeatedly to a document. Changing messageReconnectTimeout in y-websocket.js:32 to a very low number like 500, for example, works well.

I was tempted to encapsulate all clean-up behavior in a method on WSSharedDoc, but I figured the smallest effective change would be more helpful in this case.

EDIT: This fix greatly improved memory usage on my server, but I'm still seeing a leak, though it seems to be a different, much smaller one. Before, my logs showed a standard leak: positive slope line. Now they show the expected sawtooth, but still trending ever-so-slightly upwards. I haven't tracked it down, but in the meantime I've set a delay on document destruction. The repeated disconnects are what cause the leak, so instead of destroying a document immediately upon closing the final connection, I set a delay of 30 seconds; if no further clients connect in the time window, I finalize destroying the document. This smooths out the memory usage and prevents whatever allocation is causing the leak in the first place. This seems like a very application-specific band-aid, but just thought I'd share my approach.







