### PR TITLE
Add HOST environment variable to configure websocket-server bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ wsOpts = {
 Start a y-websocket server:
 
 ```sh
-PORT=1234 npx y-websocket-server
+HOST=localhost PORT=1234 npx y-websocket-server
 ```
 
-Since npm symlinks the `y-websocket-server` executable from your local `./node_modules/.bin` folder, you can simply run npx. The `PORT` environment variable already defaults to 1234.
+Since npm symlinks the `y-websocket-server` executable from your local `./node_modules/.bin` folder, you can simply run npx. The `PORT` environment variable already defaults to 1234, and `HOST` defaults to `localhost`.
 
 ### Websocket Server with Persistence
 
@@ -97,7 +97,7 @@ Persist document updates in a LevelDB database.
 See [LevelDB Persistence](https://github.com/yjs/y-leveldb) for more info.
 
 ```sh
-PORT=1234 YPERSISTENCE=./dbDir node ./node_modules/y-websocket/bin/server.js
+HOST=localhost PORT=1234 YPERSISTENCE=./dbDir node ./node_modules/y-websocket/bin/server.js
 ```
 
 ### Websocket Server with HTTP callback

--- a/bin/server.js
+++ b/bin/server.js
@@ -8,6 +8,7 @@ const http = require('http')
 const wss = new WebSocket.Server({ noServer: true })
 const setupWSConnection = require('./utils.js').setupWSConnection
 
+const host = process.env.HOST || 'localhost'
 const port = process.env.PORT || 1234
 
 const server = http.createServer((request, response) => {
@@ -28,6 +29,6 @@ server.on('upgrade', (request, socket, head) => {
   wss.handleUpgrade(request, socket, head, handleAuth)
 })
 
-server.listen(port)
+server.listen({host, port})
 
-console.log('running on port', port)
+console.log(`running at '${host}' on port ${port}`)


### PR DESCRIPTION
This change provides a `HOST` environment variable setting for the `y-websocket` server (default: `localhost`), similar to the existing `PORT` variable, to configure the network listen bind address for the websocket server.