### PR TITLE
enhancement: output typings for bin/utils.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 tmp
+*.d.ts

--- a/bin/callback.js
+++ b/bin/callback.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 const http = require('http')
 
 const CALLBACK_URL = process.env.CALLBACK_URL ? new URL(process.env.CALLBACK_URL) : null

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 const Y = require('yjs')
 const syncProtocol = require('y-protocols/dist/sync.cjs')
 const awarenessProtocol = require('y-protocols/dist/awareness.cjs')
@@ -223,9 +224,11 @@ const send = (doc, conn, m) => {
 const pingTimeout = 30000
 
 /**
- * @param {any} conn
- * @param {any} req
- * @param {any} opts
+ * @param {WebSocket} conn
+ * @param {import('http').IncomingMessage} req
+ * @param {object} [opts]
+ * @param {string} [opts.docName]
+ * @param {boolean} [opts.gc]
  */
 exports.setupWSConnection = (conn, req, { docName = req.url.slice(1).split('?')[0], gc = true } = {}) => {
   conn.binaryType = 'arraybuffer'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Websockets provider for Yjs",
   "main": "./dist/y-websocket.cjs",
   "module": "./src/y-websocket.js",
-  "types": "./dist/src/y-websocket.d.ts",
+  "types": "./src/y-websocket.d.ts",
   "sideEffects": false,
   "funding": {
     "type": "GitHub Sponsors ❤",
@@ -15,7 +15,7 @@
     "dist": "rm -rf dist && rollup -c && tsc",
     "lint": "standard && tsc",
     "test": "npm run lint",
-    "preversion": "npm run lint && npm run dist && test -e dist/src/y-websocket.d.ts && test -e dist/y-websocket.cjs"
+    "preversion": "npm run lint && npm run dist && test -e src/y-websocket.d.ts && test -e dist/y-websocket.cjs"
   },
   "bin": {
     "y-websocket-server": "./bin/server.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                        /* Redirect output structure to the directory. */
-    "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
@@ -58,5 +58,5 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     // "maxNodeModuleJsDepth": 5
   },
-  "include": ["./src/y-websocket.js"]
+  "include": ["./src/y-websocket.js", "./bin/utils.js"]
 }


### PR DESCRIPTION
Sounds like their may be major improvements coming that obsolete this, but for the time being this is the tweaks I've made to get typings working for `import { setPersistence, setupWSConnection } from '@stoplight/y-websocket/bin/utils'`. Dunno if they'd be of interest to you but figured I'd share them.

<sub><a href="https://huly.app/guest/w-githubdmonad-yjs-660d5772-70f06a0a22-d28cf5?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBkNjU1MThjN2YzNTBiMTEyMTQ3YmMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZG1vbmFkLXlqcy02NjBkNTc3Mi03MGYwNmEwYTIyLWQyOGNmNSIsInByb2R1Y3RJZCI6IiJ9.4-jlohTQ9776Q76JMdVNrIrVbMwFho3lYL8EDteEgv8">Huly&reg;: <b>YJS-728</b></a></sub>