### PR TITLE
fix: Memory leak with old versions of yjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1996,12 +1996,23 @@
       }
     },
     "yjs": {
-      "version": "13.4.1",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.4.1.tgz",
-      "integrity": "sha512-kIh0sprCTzIm2qyr1VsovkvjKzD2GR4WcU/McJpLAEvImCJHA78Q3S6uSLnhZX0i7FQdrLPCRT8DtTPEH73jnw==",
+      "version": "13.4.12",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.4.12.tgz",
+      "integrity": "sha512-ABmFknpmjcGOOWx6m4dTsjEWsN77+jHTI5DbjbwUu5t9ni1teUPOrdZtsNwQDuNPTdwGpiU9MJtIr7W6dgr9aw==",
       "dev": true,
       "requires": {
-        "lib0": "^0.2.33"
+        "lib0": "^0.2.35"
+      },
+      "dependencies": {
+        "lib0": {
+          "version": "0.2.35",
+          "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.35.tgz",
+          "integrity": "sha512-drVD3EscB3TIxiFzceuZg7oF5Z6I8a0KX+7FowNcAXOEsTej/hlHB+ElJ8Pa/Ge73Gy3fklSJtPxpNd2PajdWg==",
+          "dev": true,
+          "requires": {
+            "isomorphic.js": "^0.1.3"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "rollup-cli": "^1.0.9",
     "standard": "^12.0.1",
     "typescript": "^3.9.6",
-    "yjs": "^13.4.1"
+    "yjs": "^13.4.6"
   },
   "peerDependenies": {
-    "yjs": "^13.0.0"
+    "yjs": "^13.4.6"
   },
   "optionalDependencies": {
     "ws": "^6.2.1",


### PR DESCRIPTION
Versions of yjs prior to `13.4.6` did not emit a `"destroy"` event when a doc is destroyed, meaning that doc's in the websocket server memory are not correctly cleaned up.

closes #47 