### PR TITLE
Message handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "y-websocket",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "y-websocket",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Websockets provider for Yjs",
   "main": "./dist/y-websocket.cjs",
   "module": "./src/y-websocket.js",

--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -171,6 +171,13 @@ const broadcastMessage = (provider, buf) => {
 }
 
 /**
+ * @function messagePreProcess
+ * @param {object} eventData
+ * @return {ArrayBuffer} 
+ */
+const messagePreProcess = (eventData) => {return eventData}
+
+/**
  * Websocket Provider for Yjs. Creates a websocket connection to sync the shared document.
  * The document name is attached to the provided url. I.e. the following example
  * creates a websocket connection to http://localhost:1234/my-document-name
@@ -194,7 +201,7 @@ export class WebsocketProvider extends Observable {
    * @param {Object<string,string>} [opts.params]
    * @param {typeof WebSocket} [opts.WebSocketPolyfill] Optionall provide a WebSocket polyfill
    * @param {number} [opts.resyncInterval] Request server state every `resyncInterval` milliseconds
-   * @param {any} [opts.messagePreProcess] Optional pre-processing on incomeing messages
+   * @param {messagePreProcess} [opts.messagePreProcess] Optional pre-processing on incomeing messages
    */
   constructor (serverUrl, roomname, doc, {
     connect = true,

--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -97,11 +97,11 @@ const setupWS = provider => {
 
     websocket.onmessage = event => {
       provider.wsLastMessageReceived = time.getUnixTime()
-      let eventData = event.data
+      let _event = event
       if (provider.messagePreProcess && typeof provider.messagePreProcess === 'function') {
-          eventData = provider.messagePreProcess(eventData)
+        provider.messagePreProcess(_event)
       }
-      const encoder = readMessage(provider, new Uint8Array(eventData), true)
+      const encoder = readMessage(provider, _event.data, true)
       if (encoding.length(encoder) > 1) {
         websocket.send(encoding.toUint8Array(encoder))
       }
@@ -209,7 +209,7 @@ export class WebsocketProvider extends Observable {
     params = {},
     WebSocketPolyfill = WebSocket,
     resyncInterval = -1,
-    messagePreProcess = (message) => {message}
+    messagePreProcess = event => new Uint8Array(event.data)
   } = {}) {
     super()
     // ensure that url is always ends with /


### PR DESCRIPTION
I haven't tried my hand at writing JSDoc before so please confirm I didn't do something boneheaded here

My problem statement is that my server (API Gateway) wont allow me to transmit my data in binary, so I had to base64 encode it which means that I need to tell y-quill to convert that data to unit8array/buffer -- I think it'd be helpful to future proof by allowing the user to provide a function that pre-processes their websocket events; with the default/fallback behavior of your typical processing (reading into a unit8array)

<sub><a href="https://huly.app/guest/w-githubdmonad-yjs-660d5772-70f06a0a22-d28cf5?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBkNjU1MzhjN2YzNTBiMTEyMTQ3YzYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZG1vbmFkLXlqcy02NjBkNTc3Mi03MGYwNmEwYTIyLWQyOGNmNSIsInByb2R1Y3RJZCI6IiJ9.39wf06AmZI4WxBsVLLJVpkhqvhOExgZ6EyE_xQwqQes">Huly&reg;: <b>YJS-730</b></a></sub>