### PR TITLE
Add exit handler for Node.js environments, fix #51 #55

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -276,9 +276,18 @@ export class WebsocketProvider extends Observable {
       encoding.writeVarUint8Array(encoder, awarenessProtocol.encodeAwarenessUpdate(awareness, changedClients))
       broadcastMessage(this, encoding.toUint8Array(encoder))
     }
-    window.addEventListener('beforeunload', () => {
-      awarenessProtocol.removeAwarenessStates(this.awareness, [doc.clientID], 'window unload')
-    })
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('beforeunload', () => {
+        awarenessProtocol.removeAwarenessStates(this.awareness, [doc.clientID], 'window unload');
+      });
+    }
+    else if (typeof process !== 'undefined') {
+      process.on('exit', () => {
+          awarenessProtocol.removeAwarenessStates(this.awareness, [doc.clientID], 'window unload');
+      });
+    }
+    
     awareness.on('update', this._awarenessUpdateHandler)
     this._checkInterval = /** @type {any} */ (setInterval(() => {
       if (this.wsconnected && messageReconnectTimeout < time.getUnixTime() - this.wsLastMessageReceived) {


### PR DESCRIPTION
This PR introduces:
1. A check if the provider is running in a browser or Node.js context.
2. Registers an `exit` handler for Node.js environments.

The check isn’t very strict, but I don’t see a reason why someone would benefit from manipulating the check. From what I know it’s pretty complex to make that check harder to manipulate.

A very similar change in lib0 is necessary to make y-websocket work in Node.js (again?). I’ll send a PR there too. Let me know if a change to the PR would make it easier to merge it. Happy to update it.