### PR TITLE
Send full html document model instead of text

### DIFF
--- a/bin/callback.js
+++ b/bin/callback.js
@@ -22,7 +22,7 @@ exports.callbackHandler = (update, origin, doc) => {
     const sharedObjectType = CALLBACK_OBJECTS[sharedObjectName]
     dataToSend.data[sharedObjectName] = {
       type: sharedObjectType,
-      content: getContent(sharedObjectName, sharedObjectType, doc).toJSON()
+      content: getContent(sharedObjectName, sharedObjectType, doc).toDelta()
     }
   })
   callbackRequest(CALLBACK_URL, CALLBACK_TIMEOUT, dataToSend)


### PR DESCRIPTION
closes #50 

This PR allows to get full quill's document model instead of just stripped text.

Before changes
```elixir
%{
  "data" => %{
    "quill" => %{
      "content" => "hello world",
      "type" => "Text"
    }
  }
}
```

After changes
```elixir
%{
  "data" => %{
    "quill" => %{
      "content" => [
        %{"insert" => "hello "},
        %{
          "attributes" => %{
            "background" => "#f8f8f8",
            "bold" => true,
            "color" => "#434343"
          },
          "insert" => "world"
        },
      ],
      "type" => "Text"
    }
  }
}
```