### PR TITLE
Let caller of setupWSConnection create their own callback function

### DIFF
--- a/bin/callback.js
+++ b/bin/callback.js
@@ -4,14 +4,14 @@ const CALLBACK_URL = process.env.CALLBACK_URL ? new URL(process.env.CALLBACK_URL
 const CALLBACK_TIMEOUT = process.env.CALLBACK_TIMEOUT || 5000
 const CALLBACK_OBJECTS = process.env.CALLBACK_OBJECTS ? JSON.parse(process.env.CALLBACK_OBJECTS) : {}
 
-exports.isCallbackSet = !!CALLBACK_URL
+exports.isDefaultCallbackSet = !!CALLBACK_URL
 
 /**
  * @param {Uint8Array} update
  * @param {any} origin
  * @param {WSSharedDoc} doc
  */
-exports.callbackHandler = (update, origin, doc) => {
+exports.defaultCallbackHandler = (update, origin, doc) => {
   const room = doc.name
   const dataToSend = {
     room: room,
@@ -58,6 +58,7 @@ const callbackRequest = (url, timeout, data) => {
   req.write(data)
   req.end()
 }
+exports.callbackRequest = callbackRequest
 
 /**
  * @param {string} objName
@@ -74,3 +75,4 @@ const getContent = (objName, objType, doc) => {
     default : return {}
   }
 }
+exports.getContent = getContent


### PR DESCRIPTION
I proposed the following question in #60:

> Would it make sense to consider a "plugin" style of configuration for callbacks?

This PR represents an attempt at this, by making `callbackHandler` a parameter that can be passed in to setupWSConnection. If none is provided, but env vars such as CALLBACK_URL etc. are given, then the "default callbackHandler" is used, as before.

Would this be a good way forward?