### PR TITLE
Fix a `peerDependencies` typo in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.9.9",
     "yjs": "^13.5.0"
   },
-  "peerDependenies": {
+  "peerDependencies": {
     "yjs": "^13.5.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This way, it is made explicit we need to install `yjs` alongside `y-websocket`.