### PR TITLE
Support transforming data for WebSocket transport.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,13 @@ wsOpts = {
   // E.g. In nodejs, you could specify WebsocketPolyfill = require('ws')
   WebsocketPolyfill: Websocket,
   // Specify an existing Awareness instance - see https://github.com/yjs/y-protocols
-  awareness: new awarenessProtocol.Awareness(ydoc)
+  awareness: new awarenessProtocol.Awareness(ydoc),
+  // Specify a transformer for incoming Websocket data, i.e. fromBase64
+  // It should take the data from the WebSocket and output a Uint8Array
+  transformRead: data => Uint8Array,
+  // Specify a transformer for outgoing Websocket data, i.e. toBase64
+  // It should take a Uint8Array and output data to send on the WebSocket
+  transformWrite: Uint8Array => data
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2113,9 +2113,9 @@
       }
     },
     "yjs": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.5.6.tgz",
-      "integrity": "sha512-0ebPpLB/zizJbWaFUDRarWbXiXYD0OMDOCa8ZqkVVWQzeIoMRbmbNwB3suZ9YwD0bV4Su9RLn8M/bvGzIwX3hA==",
+      "version": "13.5.12",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.5.12.tgz",
+      "integrity": "sha512-/buy1kh8Ls+t733Lgov9hiNxCsjHSCymTuZNahj2hsPNoGbvnSdDmCz9Z4F19Yr1eUAAXQLJF3q7fiBcvPC6Qg==",
       "dev": true,
       "requires": {
         "lib0": "^0.2.41"


### PR DESCRIPTION
On [AWS I am not able to use binary in WebSocket payloads](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-develop-binary-media-types.html), this PR adds two backwards compatible options `transformRead` and `transformWrite` to convert the incoming and outgoing data on the WebSocket.

Example usage

```js
import { fromBase64, toBase64 } from 'lib0/buffer';

new WebsocketProvider(
  'ws://localhost:1234',
  'my-room-name',
  yDoc,
  {
    transformRead: fromBase64,
    transformWrite: toBase64
  }
);
```