### PR TITLE
correct npx directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository implements a basic server that you can adopt to your specific us
 Start a y-websocket server:
 
 ```sh
-HOST=localhost PORT=1234 npx y-websocket-server
+HOST=localhost PORT=1234 npx y-websocket
 ```
 
 ### Client Code:
@@ -101,10 +101,10 @@ wsOpts = {
 Start a y-websocket server:
 
 ```sh
-HOST=localhost PORT=1234 npx y-websocket-server
+HOST=localhost PORT=1234 npx y-websocket
 ```
 
-Since npm symlinks the `y-websocket-server` executable from your local `./node_modules/.bin` folder, you can simply run npx. The `PORT` environment variable already defaults to 1234, and `HOST` defaults to `localhost`.
+Since npm symlinks the `y-websocket` executable from your local `./node_modules/.bin` folder, you can simply run npx. The `PORT` environment variable already defaults to 1234, and `HOST` defaults to `localhost`.
 
 ### Websocket Server with Persistence
 


### PR DESCRIPTION
according to the [doc](https://docs.npmjs.com/cli/v8/commands/npx), npx needs package name rather than the binary name. so executing `npx y-websocket-server` would not download and run the server binary in `y-websocket`, it would download from [y-websocket-server](https://npmjs.com/package/y-websocket-server) instead, which could lead to remote arbitrage code execution.