### PR TITLE
Call onclose when closing the connection in the checkinterval

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -289,10 +289,18 @@ export class WebsocketProvider extends Observable {
       if (this.wsconnected && messageReconnectTimeout < time.getUnixTime() - this.wsLastMessageReceived) {
         // no message received in a long time - not even your own awareness
         // updates (which are updated every 15 seconds)
-        /** @type {WebSocket} */ (this.ws).close()
 
-        // Websocket does not call onclose when the socket is closed manually
-        /** @type {WebSocket} */ (this.ws).onclose()
+        if (!this.ws) {
+          setupWS(this);
+          return;
+        };
+
+        this.ws.close();
+        
+        if (typeof this.ws.onclose === 'function') {
+          // ws.onclose is not called after the websocket is closed manually in Safari
+          this.ws.onclose(new CloseEvent('manual close'));
+        }
       }
     }, messageReconnectTimeout / 10))
     if (connect) {

--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -290,6 +290,9 @@ export class WebsocketProvider extends Observable {
         // no message received in a long time - not even your own awareness
         // updates (which are updated every 15 seconds)
         /** @type {WebSocket} */ (this.ws).close()
+
+        // Websocket does not call onclose when the socket is closed manually
+        /** @type {WebSocket} */ (this.ws).onclose()
       }
     }, messageReconnectTimeout / 10))
     if (connect) {


### PR DESCRIPTION
**Context**
In Safari the Websocket does not call onclose when the socket is closed manually.

**The problem**
This means that if a connection is closed in the interval in Safari it doesn't try to reconnect. Users end up in a state where `y-websocket` states that they are connected. But they are disconnected and `y-websocket` doesn't try to reconnect... users lose their edits.

**Reproduce**
It's easy to reproduce. Switch from one wifi network to another (i.e. to your phone using tethering) and you'll see it disconnects silently and never reconnects.