### PR TITLE
Fixing errors with CommonJS import of `ws`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ wsProvider.on('status', event => {
 The WebSocket provider requires a [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) object to create connection to a server. You can polyfill WebSocket support in Node.js using the [`ws` package](https://www.npmjs.com/package/ws).
 
 ```js
-const wsProvider = new WebsocketProvider('ws://localhost:1234', 'my-roomname', doc, { WebSocketPolyfill: require('ws') })
+import ws from 'ws';
+
+const wsProvider = new WebsocketProvider('ws://localhost:1234', 'my-roomname', doc, { WebSocketPolyfill: ws })
 ```
 
 ## API

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/y-websocket.cjs",
   "module": "./src/y-websocket.js",
   "types": "./dist/src/y-websocket.d.ts",
+  "type": "module",
   "sideEffects": false,
   "funding": {
     "type": "GitHub Sponsors ❤",

--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -19,6 +19,7 @@ import * as awarenessProtocol from 'y-protocols/awareness'
 import { Observable } from 'lib0/observable'
 import * as math from 'lib0/math'
 import * as url from 'lib0/url'
+import { WebSocket } from 'ws'
 
 const messageSync = 0
 const messageQueryAwareness = 3

--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -19,7 +19,8 @@ import * as awarenessProtocol from 'y-protocols/awareness'
 import { Observable } from 'lib0/observable'
 import * as math from 'lib0/math'
 import * as url from 'lib0/url'
-import { WebSocket } from 'ws'
+import pkg from 'ws';
+const { WebSocket } = pkg;
 
 const messageSync = 0
 const messageQueryAwareness = 3


### PR DESCRIPTION
Hello there!

When attempting to get a Hello World of `y-websocket` working as a client running node `v17.8.0`, I encountered a few errors regarding missing imports for `ws` in `src/y-websocket.js`.  This PR includes the following to get a fully functioning Hello World moving from the client's perspective:

- Importing `WebSocket` explicitly from `ws`
- Updating the `package.json` to explicitly call out this as an ES module (similar PRs: #104)
- Updating `README.md` for updated boilerplate