### PR TITLE
Update utils.js

### DIFF
--- a/bin/utils.js
+++ b/bin/utils.js
@@ -168,6 +168,10 @@ const messageListener = (conn, doc, message) => {
       case messageSync:
         encoding.writeVarUint(encoder, messageSync)
         syncProtocol.readSyncMessage(decoder, encoder, doc, null)
+        
+        // If the `encoder` only contains the type of reply message and no 
+        // message, there is no need to send the message. When `encoder` only 
+        // contains the type of reply, its length is 1.
         if (encoding.length(encoder) > 1) {
           send(doc, conn, encoding.toUint8Array(encoder))
         }


### PR DESCRIPTION
Added a comment to clarify why reply messages are not sent when their length is 1. Alternatively we could also create a function with a descriptive name of the check being performed,

```js
function hasMessage(encoder) {
    return encoding.length(encoder) > 1;
}
```

The `if` statement would then look something like,

```js
if (hasMessage(encoder)) {
    send(...);
}
```

Thoughts?