### PR TITLE
Export message type constants

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -20,10 +20,10 @@ import { Observable } from 'lib0/observable'
 import * as math from 'lib0/math'
 import * as url from 'lib0/url'
 
-const messageSync = 0
-const messageQueryAwareness = 3
-const messageAwareness = 1
-const messageAuth = 2
+export const messageSync = 0
+export const messageQueryAwareness = 3
+export const messageAwareness = 1
+export const messageAuth = 2
 
 /**
  *                       encoder,          decoder,          provider,          emitSynced, messageType


### PR DESCRIPTION
When constructing messages to seend to a peer using y-websocket, the constants used to identify the type of message must be re-defined when the message is constructed because they're not exported from y-websocket.

We can see this issue in the sample server in this same repo. The values are redifined [here](https://github.com/yjs/y-websocket/blob/625a9d52ba8bcff90a941d51ae151869e220f368/bin/utils.js#L70-L71). Best to have a single source of truth and use values exported by the library.