### PR TITLE
Add a timeout status event 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ wsOpts = {
   <dd>Destroy this wsProvider instance. Disconnects from the server and removes all event handlers.</dd>
   <b><code>wsProvider.on('sync', function(isSynced: boolean))</code></b>
   <dd>Add an event listener for the sync event that is fired when the client received content from the server.</dd>
-  <b><code>wsProvider.on('status', function({ status: 'disconnected' | 'connecting' | 'connected' }))</code></b>
+  <b><code>wsProvider.on('status', function({ status: 'disconnected' | 'connecting' | 'connected' | 'timeout' }))</code></b>
   <dd>Receive updates about the current connection status.</dd>
+  <dd>Note: The `timeout` event fires when there hasn't been any update on the WebSocket for `messageReconnectTimeout`, and the WebSocket 
+    is marked for closing. The `disconnected` event is only fired after the closing handshake (which can get delayed when there is network disconenction).</dd>
   <b><code>wsProvider.on('connection-close', function(WSClosedEvent))</code></b>
   <dd>Fires when the underlying websocket connection is closed. It forwards the websocket event to this event handler.</dd>
   <b><code>wsProvider.on('connection-error', function(WSErrorEvent))</code></b>

--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -372,6 +372,14 @@ export class WebsocketProvider extends Observable {
         // no message received in a long time - not even your own awareness
         // updates (which are updated every 15 seconds)
         /** @type {WebSocket} */ (this.ws).close()
+        // Closing a WebSocket instance, especially in browsers will not
+        // cause it to immediately close, instead, it initiates the
+        // closing handshake (https://www.rfc-editor.org/rfc/rfc6455.html#section-1.4)
+        // which will delay firing of 'close' event.
+        // A dedicated 'timeout' status update can be used to detect this state
+        this.emit('status', [{
+          status: 'timeout'
+        }]);
       }
     }, messageReconnectTimeout / 10))
     if (connect) {


### PR DESCRIPTION
- A new status event: 'timeout' is fired when there has been inactivity on the websocket for a while and the websocket is marked for closing
- This is really handy with detecting network disconnection, because in that case the websocket does not really fire the 'close' event until the browser has finished the closing handshake. 
- Added documentation for this