### PR TITLE
Adds support for passing Authentication Credentials & Query Params via CALLBACK_URL

### DIFF
--- a/bin/callback.js
+++ b/bin/callback.js
@@ -38,9 +38,14 @@ const callbackRequest = (url, timeout, data) => {
   const options = {
     hostname: url.hostname,
     port: url.port,
-    path: url.pathname,
+    path: url.pathname + url.search,
     timeout,
     method: 'POST',
+    auth: (
+      (url.username || url.password)
+      ? url.username + ':' + url.password
+      : ''
+    ),
     headers: {
       'Content-Type': 'application/json',
       'Content-Length': data.length


### PR DESCRIPTION
This change allows for a server  to contain both query params and optional HTTP Basic Auth credentials.

Currently no mechanism exists for a `CALLBACK_URL` to contain an authentication token either in the query string or as basic auth. A lack of such mechanism limits the utility of the CALLBACK_URL over unsecured networks or multi-node setups.