### PR TITLE
fix: add type declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     ".": {
       "module": "./src/y-websocket.js",
       "import": "./src/y-websocket.js",
-      "require": "./dist/y-websocket.cjs"
+      "require": "./dist/y-websocket.cjs",
+      "types": "./dist/src/y-websocket.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
Fix potential errors when import using `import {WebsocketProvider} from 'y-websocket';` in typescript project

> TS7016: Could not find a declaration file for module 'y-websocket'. '/Users/xiaotian/WebstormProjects/affine-demo-thorseraq/node_modules/.pnpm/y-websocket@1.5.0_yjs@13.6.0/node_modules/y-websocket/src/y-websocket.js' implicitly has an 'any' type.   There are types at '/Users/xiaotian/WebstormProjects/affine-demo-thorseraq/node_modules/y-websocket/dist/src/y-websocket.d.ts', but this result could not be resolved when respecting package.json "exports". The 'y-websocket' library may need to update its package.json or typings.

<img width="1307" alt="image" src="https://user-images.githubusercontent.com/20554850/235669281-6f19f5b5-300c-49c1-9311-9a5be87d8f98.png">
