### PR TITLE
Update exports in package.json to work with typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     ".": {
       "module": "./src/y-websocket.js",
       "import": "./src/y-websocket.js",
-      "require": "./dist/y-websocket.cjs"
+      "require": "./dist/y-websocket.cjs",
+      "types": "./dist/src/y-websocket.d.ts",
     }
   },
   "repository": {


### PR DESCRIPTION
There is a bug when using y-websocket with typescript where typescript can't find the required types of the library because it isn't exported in the package.json file of the library.

This is the error:
> Could not find a declaration file for module 'y-websocket'. '<LOCAL_PROJECT_DIRECTORY>/node_modules/y-websocket/src/y-websocket.js' implicitly has an 'any' type.
  There are types at '<LOCAL_PROJECT_DIRECTORY>/node_modules/y-websocket/dist/src/y-websocket.d.ts', but this result could not be resolved when respecting package.json "exports". The 'y-websocket' library may need to update its package.json or typings.ts(7016)
  
 By making this change, I was able to fix the error.
 
 It might also be related to the issue #72 