### PR TITLE
Allow change config after creating provider

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -264,15 +264,13 @@ export class WebsocketProvider extends Observable {
     while (serverUrl[serverUrl.length - 1] === '/') {
       serverUrl = serverUrl.slice(0, serverUrl.length - 1)
     }
-    const encodedParams = url.encodeQueryParams(params)
     this.maxBackoffTime = maxBackoffTime
-    this.bcChannel = serverUrl + '/' + roomname
-    this.url = serverUrl + '/' + roomname +
-      (encodedParams.length === 0 ? '' : '?' + encodedParams)
+    this.serverUrl = serverUrl
     this.roomname = roomname
     this.doc = doc
     this._WS = WebSocketPolyfill
     this.awareness = awareness
+    this.params = params
     this.wsconnected = false
     this.wsconnecting = false
     this.bcconnected = false
@@ -377,6 +375,15 @@ export class WebsocketProvider extends Observable {
     if (connect) {
       this.connect()
     }
+  }
+
+  get url () {
+    const encodedParams = url.encodeQueryParams(this.params)
+    return this.serverUrl + '/' + this.roomname + (encodedParams.length === 0 ? '' : '?' + encodedParams)
+  }
+
+  get bcChannel () {
+    return this.serverUrl + '/' + this.roomname
   }
 
   /**


### PR DESCRIPTION
Authentication credentials (taking JWT as an example) can be placed in params.

If it is an accessToken, when the accessToken expires, we need to get a new accessToken by refresh Token, and use this new accessToken to reconnect to the Websocket server.

y-websocket use polling interval to try to reconnect when connection failed, so, allow to directly modify the config containing the token inside the WebsocketProvider instance, then the new token can be used to reconnect to server without re-creating the WebsocketProvider instance.

code changes:

* Save `serverUrl` as a public property
* Save `params` as a public property
* Make `url` property as a readonly computed property
* Make `bcChannel` property as a readonly computed property
