### PR TITLE
Replace the deprecated unload event with pagehide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,10 @@
         "typescript": "^4.9.5",
         "yjs": "^13.5.0"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -2656,9 +2660,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -3078,9 +3082,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"

--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -358,7 +358,7 @@ export class WebsocketProvider extends Observable {
       )
     }
     if (typeof window !== 'undefined') {
-      window.addEventListener('unload', this._unloadHandler)
+      window.addEventListener('pagehide', this._unloadHandler)
     } else if (typeof process !== 'undefined') {
       process.on('exit', this._unloadHandler)
     }
@@ -401,7 +401,7 @@ export class WebsocketProvider extends Observable {
     clearInterval(this._checkInterval)
     this.disconnect()
     if (typeof window !== 'undefined') {
-      window.removeEventListener('unload', this._unloadHandler)
+      window.removeEventListener('pagehide', this._unloadHandler)
     } else if (typeof process !== 'undefined') {
       process.off('exit', this._unloadHandler)
     }


### PR DESCRIPTION
The unloadHandler is called by an eventListener for the 'unload' event when the user moves away from the page being served by y-websocket.  However, the unload event is now deprecated (see https://web.dev/articles/bfcache?utm_source=lighthouse&utm_medium=devtools#never-use-the-unload-event ) and the recommendation is to replace it with the 'pagehide' event.  This PR does that, in both locations in y-websocket.js where it is used.