### PR TITLE
fix "TypeError: process.off is not a function" with bundlers

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -399,7 +399,7 @@ export class WebsocketProvider extends Observable {
     }
     clearInterval(this._checkInterval)
     this.disconnect()
-    if (typeof process !== 'undefined') {
+    if (env.isNode && typeof process !== 'undefined') {
       process.off('exit', this._exitHandler)
     }
     this.awareness.off('update', this._awarenessUpdateHandler)


### PR DESCRIPTION
Fixes error `TypeError: process.off is not a function` caused by polyfill bundlers. See: https://github.com/yjs/y-websocket/issues/166