### PR TITLE
Incorrect content-length in callback.js when body contains non-ascii characters

### DIFF
--- a/bin/callback.cjs
+++ b/bin/callback.cjs
@@ -44,7 +44,7 @@ const callbackRequest = (url, timeout, data) => {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Content-Length': data.length
+      'Content-Length': Buffer.byteLength(data)
     }
   }
   const req = http.request(options)


### PR DESCRIPTION
Incorrect content-length in callback.js when body contains non-ascii characters
https://github.com/yjs/y-websocket/issues/52