### PR TITLE
fix: move y-leveldb to peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Persist document updates in a LevelDB database.
 
 See [LevelDB Persistence](https://github.com/yjs/y-leveldb) for more info.
 
+You must have `y-leveldb` installed before running this command, which you could do with `npm i y-leveldb -g`.
+
 ```sh
 HOST=localhost PORT=1234 YPERSISTENCE=./dbDir node ./node_modules/y-websocket/bin/server.cjs
 ```

--- a/package.json
+++ b/package.json
@@ -73,11 +73,11 @@
     "yjs": "^13.5.0"
   },
   "peerDependencies": {
-    "yjs": "^13.5.6"
+    "yjs": "^13.5.6",
+    "y-leveldb": "^0.1.0"
   },
   "optionalDependencies": {
-    "ws": "^6.2.1",
-    "y-leveldb": "^0.1.0"
+    "ws": "^6.2.1"
   },
   "engines": {
     "npm": ">=8.0.0",


### PR DESCRIPTION
y-leveldb is not always used, only when persistenceDir is a string or YPERSISTENCE is set. y-leveldb is also quite a node_modules bloat, as it relies on level and leveldown (more than 25MB of extra install space needed).

Therefore I propose to move it to a peer dep and if a user wants to use it, then they can run `npm i y-leveldb -g` before.

