### PR TITLE
Fix comment about trailing slashes

### DIFF
--- a/src/y-websocket.js
+++ b/src/y-websocket.js
@@ -278,7 +278,7 @@ export class WebsocketProvider extends ObservableV2 {
     disableBc = false
   } = {}) {
     super()
-    // ensure that url is always ends with /
+    // ensure that serverUrl does not end with /
     while (serverUrl[serverUrl.length - 1] === '/') {
       serverUrl = serverUrl.slice(0, serverUrl.length - 1)
     }


### PR DESCRIPTION
While reading `src/y-websocket.js` I noticed that the code and the comment about trailing slash in `serverUrl` handling did not agree. I modified the comment to more accurately describe what the code does.